### PR TITLE
Update XML format to match Anthropic's example

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,19 +107,25 @@ Contents of file3.txt
 ### XML Output
 
 Anthropic has provided [specific guidelines](https://docs.anthropic.com/claude/docs/long-context-window-tips) for optimally structuring prompts to take advantage of Claude's extended context window.
-
 To structure the output in this way, use the optional `--xml` flag, which will produce output like this:
-
 ```xml
 Here are some documents for you to reference for your task:
-
 <documents>
-<document path="my_directory/file1.txt">
+<document index="1">
+<source>
+my_directory/file1.txt
+</source>
+<document_content>
 Contents of file1.txt
+</document_content>
 </document>
-
-<document path="my_directory/file2.txt">
+<document index="2">
+<source>
+my_directory/file2.txt
+</source>
+<document_content>
 Contents of file2.txt
+</document_content>
 </document>
 ...
 </documents>

--- a/files_to_prompt/cli.py
+++ b/files_to_prompt/cli.py
@@ -39,12 +39,12 @@ def print_default(path, content):
 
 def print_as_xml(path, content, index):
     click.echo(f'<document index="{index}">')
-    click.echo("  <source>")
-    click.echo(f"    {path}")
-    click.echo("  </source>")
-    click.echo("  <document_content>")
+    click.echo("<source>")
+    click.echo(f"{path}")
+    click.echo("</source>")
+    click.echo("<document_content>")
     click.echo(content)
-    click.echo("  </document_content>")
+    click.echo("</document_content>")
     click.echo("</document>")
 
 
@@ -141,20 +141,20 @@ def cli(paths, include_hidden, ignore_gitignore, ignore_patterns, xml):
     Here are some documents for you to reference for your task:
     <documents>
     <document index="1">
-      <source>
-      path/to/file1.txt
-      </source>
-      <document_content>
-      Contents of file1.txt
-      </document_content>
+    <source>
+    path/to/file1.txt
+    </source>
+    <document_content>
+    Contents of file1.txt
+    </document_content>
     </document>
     <document index="2">
-      <source>
-      path/to/file2.txt
-      </source>
-      <document_content>
-      Contents of file2.txt
-      </document_content>
+    <source>
+    path/to/file2.txt
+    </source>
+    <document_content>
+    Contents of file2.txt
+    </document_content>
     </document>
     ...
     </documents>

--- a/files_to_prompt/cli.py
+++ b/files_to_prompt/cli.py
@@ -1,6 +1,5 @@
 import os
 from fnmatch import fnmatch
-
 import click
 
 
@@ -23,9 +22,9 @@ def read_gitignore(path):
     return []
 
 
-def print_path(path, content, xml):
+def print_path(path, content, xml, index):
     if xml:
-        print_as_xml(path, content)
+        print_as_xml(path, content, index)
     else:
         print_default(path, content)
 
@@ -38,9 +37,14 @@ def print_default(path, content):
     click.echo("---")
 
 
-def print_as_xml(path, content):
-    click.echo(f'<document path="{path}">')
+def print_as_xml(path, content, index):
+    click.echo(f'<document index="{index}">')
+    click.echo("  <source>")
+    click.echo(f"    {path}")
+    click.echo("  </source>")
+    click.echo("  <document_content>")
     click.echo(content)
+    click.echo("  </document_content>")
     click.echo("</document>")
 
 
@@ -51,11 +55,13 @@ def process_path(
     gitignore_rules,
     ignore_patterns,
     xml,
+    index,  # Add index as a parameter here
 ):
     if os.path.isfile(path):
         try:
             with open(path, "r") as f:
-                print_path(path, f.read(), xml)
+                print_path(path, f.read(), xml, str(index))
+                # index += 1  # No need to increment here anymore
         except UnicodeDecodeError:
             warning_message = f"Warning: Skipping file {path} due to UnicodeDecodeError"
             click.echo(click.style(warning_message, fg="red"), err=True)
@@ -64,32 +70,30 @@ def process_path(
             if not include_hidden:
                 dirs[:] = [d for d in dirs if not d.startswith(".")]
                 files = [f for f in files if not f.startswith(".")]
-
             if not ignore_gitignore:
                 gitignore_rules.extend(read_gitignore(root))
-                dirs[:] = [
-                    d
-                    for d in dirs
-                    if not should_ignore(os.path.join(root, d), gitignore_rules)
-                ]
-                files = [
-                    f
-                    for f in files
-                    if not should_ignore(os.path.join(root, f), gitignore_rules)
-                ]
-
+            dirs[:] = [
+                d
+                for d in dirs
+                if not should_ignore(os.path.join(root, d), gitignore_rules)
+            ]
+            files = [
+                f
+                for f in files
+                if not should_ignore(os.path.join(root, f), gitignore_rules)
+            ]
             if ignore_patterns:
                 files = [
                     f
                     for f in files
                     if not any(fnmatch(f, pattern) for pattern in ignore_patterns)
                 ]
-
             for file in sorted(files):
                 file_path = os.path.join(root, file)
                 try:
                     with open(file_path, "r") as f:
-                        print_path(file_path, f.read(), xml)
+                        print_path(file_path, f.read(), xml, str(index))
+                        index += 1
                 except UnicodeDecodeError:
                     warning_message = (
                         f"Warning: Skipping file {file_path} due to UnicodeDecodeError"
@@ -126,27 +130,31 @@ def cli(paths, include_hidden, ignore_gitignore, ignore_patterns, xml):
     """
     Takes one or more paths to files or directories and outputs every file,
     recursively, each one preceded with its filename like this:
-
     path/to/file.py
     ----
     Contents of file.py goes here
-
     ---
     path/to/file2.py
     ---
     ...
-
     If the `--xml` flag is provided, the output will be structured as follows:
-
     Here are some documents for you to reference for your task:
-
     <documents>
-    <document path="path/to/file1.txt">
-    Contents of file1.txt
+    <document index="1">
+      <source>
+      path/to/file1.txt
+      </source>
+      <document_content>
+      Contents of file1.txt
+      </document_content>
     </document>
-
-    <document path="path/to/file2.txt">
-    Contents of file2.txt
+    <document index="2">
+      <source>
+      path/to/file2.txt
+      </source>
+      <document_content>
+      Contents of file2.txt
+      </document_content>
     </document>
     ...
     </documents>
@@ -157,11 +165,12 @@ def cli(paths, include_hidden, ignore_gitignore, ignore_patterns, xml):
             raise click.BadArgumentUsage(f"Path does not exist: {path}")
         if not ignore_gitignore:
             gitignore_rules.extend(read_gitignore(os.path.dirname(path)))
-        if xml and path == paths[0]:
-            click.echo("Here are some documents for you to reference for your task:")
-            click.echo()
-            click.echo("<documents>")
-
+    if xml:
+        click.echo("Here are some documents for you to reference for your task:")
+        click.echo()
+        click.echo("<documents>")
+    index = 1  # Initialize index here
+    for path in paths:
         process_path(
             path,
             include_hidden,
@@ -169,7 +178,8 @@ def cli(paths, include_hidden, ignore_gitignore, ignore_patterns, xml):
             gitignore_rules,
             ignore_patterns,
             xml,
+            index,  # Pass the index to process_path
         )
-
+        index += 1  # Increment index after processing each path
     if xml:
         click.echo("</documents>")

--- a/tests/test_files_to_prompt.py
+++ b/tests/test_files_to_prompt.py
@@ -1,7 +1,5 @@
 import os
-
 from click.testing import CliRunner
-
 from files_to_prompt.cli import cli
 
 
@@ -13,7 +11,6 @@ def test_basic_functionality(tmpdir):
             f.write("Contents of file1")
         with open("test_dir/file2.txt", "w") as f:
             f.write("Contents of file2")
-
         result = runner.invoke(cli, ["test_dir"])
         assert result.exit_code == 0
         assert "test_dir/file1.txt" in result.output
@@ -28,11 +25,9 @@ def test_include_hidden(tmpdir):
         os.makedirs("test_dir")
         with open("test_dir/.hidden.txt", "w") as f:
             f.write("Contents of hidden file")
-
         result = runner.invoke(cli, ["test_dir"])
         assert result.exit_code == 0
         assert "test_dir/.hidden.txt" not in result.output
-
         result = runner.invoke(cli, ["test_dir", "--include-hidden"])
         assert result.exit_code == 0
         assert "test_dir/.hidden.txt" in result.output
@@ -49,12 +44,10 @@ def test_ignore_gitignore(tmpdir):
             f.write("This file should be ignored")
         with open("test_dir/included.txt", "w") as f:
             f.write("This file should be included")
-
         result = runner.invoke(cli, ["test_dir"])
         assert result.exit_code == 0
         assert "test_dir/ignored.txt" not in result.output
         assert "test_dir/included.txt" in result.output
-
         result = runner.invoke(cli, ["test_dir", "--ignore-gitignore"])
         assert result.exit_code == 0
         assert "test_dir/ignored.txt" in result.output
@@ -73,7 +66,6 @@ def test_multiple_paths(tmpdir):
             f.write("Contents of file2")
         with open("single_file.txt", "w") as f:
             f.write("Contents of single file")
-
         result = runner.invoke(cli, ["test_dir1", "test_dir2", "single_file.txt"])
         assert result.exit_code == 0
         assert "test_dir1/file1.txt" in result.output
@@ -92,13 +84,11 @@ def test_ignore_patterns(tmpdir):
             f.write("This file should be ignored due to ignore patterns")
         with open("test_dir/file_to_include.txt", "w") as f:
             f.write("This file should be included")
-
         result = runner.invoke(cli, ["test_dir", "--ignore", "*.txt"])
         assert result.exit_code == 0
         assert "test_dir/file_to_ignore.txt" not in result.output
         assert "This file should be ignored due to ignore patterns" not in result.output
         assert "test_dir/file_to_include.txt" not in result.output
-
         result = runner.invoke(cli, ["test_dir", "--ignore", "file_to_ignore.*"])
         assert result.exit_code == 0
         assert "test_dir/file_to_ignore.txt" not in result.output
@@ -123,7 +113,6 @@ def test_mixed_paths_with_options(tmpdir):
             f.write("This hidden file should be included")
         with open("single_file.txt", "w") as f:
             f.write("Contents of single file")
-
         result = runner.invoke(cli, ["test_dir", "single_file.txt"])
         assert result.exit_code == 0
         assert "test_dir/ignored_in_gitignore.txt" not in result.output
@@ -132,7 +121,6 @@ def test_mixed_paths_with_options(tmpdir):
         assert "test_dir/.hidden_included.txt" not in result.output
         assert "single_file.txt" in result.output
         assert "Contents of single file" in result.output
-
         result = runner.invoke(cli, ["test_dir", "single_file.txt", "--include-hidden"])
         assert result.exit_code == 0
         assert "test_dir/ignored_in_gitignore.txt" not in result.output
@@ -141,7 +129,6 @@ def test_mixed_paths_with_options(tmpdir):
         assert "test_dir/.hidden_included.txt" in result.output
         assert "single_file.txt" in result.output
         assert "Contents of single file" in result.output
-
         result = runner.invoke(
             cli, ["test_dir", "single_file.txt", "--ignore-gitignore"]
         )
@@ -152,7 +139,6 @@ def test_mixed_paths_with_options(tmpdir):
         assert "test_dir/.hidden_included.txt" not in result.output
         assert "single_file.txt" in result.output
         assert "Contents of single file" in result.output
-
         result = runner.invoke(
             cli,
             ["test_dir", "single_file.txt", "--ignore-gitignore", "--include-hidden"],
@@ -174,13 +160,10 @@ def test_binary_file_warning(tmpdir):
             f.write(b"\xff")
         with open("test_dir/text_file.txt", "w") as f:
             f.write("This is a text file")
-
         result = runner.invoke(cli, ["test_dir"])
         assert result.exit_code == 0
-
         stdout = result.stdout
         stderr = result.stderr
-
         assert "test_dir/text_file.txt" in stdout
         assert "This is a text file" in stdout
         assert "\ntest_dir/binary_file.bin" not in stdout
@@ -198,18 +181,27 @@ def test_xml_format_dir(tmpdir):
             f.write("Contents of file1")
         with open("test_dir/file2.txt", "w") as f:
             f.write("Contents of file2")
-
         result = runner.invoke(cli, ["test_dir", "--xml"])
         assert result.exit_code == 0
         have = result.output
         want = """Here are some documents for you to reference for your task:
 
 <documents>
-<document path="test_dir/file1.txt">
+<document index="1">
+  <source>
+    test_dir/file1.txt
+  </source>
+  <document_content>
 Contents of file1
+  </document_content>
 </document>
-<document path="test_dir/file2.txt">
+<document index="2">
+  <source>
+    test_dir/file2.txt
+  </source>
+  <document_content>
 Contents of file2
+  </document_content>
 </document>
 </documents>
 """
@@ -224,21 +216,29 @@ def test_xml_format_multiple_paths(tmpdir):
             f.write("Contents of file1")
         with open("test_dir/file2.txt", "w") as f:
             f.write("Contents of file2")
-
         result = runner.invoke(
             cli, ["test_dir/file1.txt", "test_dir/file2.txt", "--xml"]
         )
-
         assert result.exit_code == 0
         have = result.output
         want = """Here are some documents for you to reference for your task:
 
 <documents>
-<document path="test_dir/file1.txt">
+<document index="1">
+  <source>
+    test_dir/file1.txt
+  </source>
+  <document_content>
 Contents of file1
+  </document_content>
 </document>
-<document path="test_dir/file2.txt">
+<document index="2">
+  <source>
+    test_dir/file2.txt
+  </source>
+  <document_content>
 Contents of file2
+  </document_content>
 </document>
 </documents>
 """

--- a/tests/test_files_to_prompt.py
+++ b/tests/test_files_to_prompt.py
@@ -188,20 +188,20 @@ def test_xml_format_dir(tmpdir):
 
 <documents>
 <document index="1">
-  <source>
-    test_dir/file1.txt
-  </source>
-  <document_content>
+<source>
+test_dir/file1.txt
+</source>
+<document_content>
 Contents of file1
-  </document_content>
+</document_content>
 </document>
 <document index="2">
-  <source>
-    test_dir/file2.txt
-  </source>
-  <document_content>
+<source>
+test_dir/file2.txt
+</source>
+<document_content>
 Contents of file2
-  </document_content>
+</document_content>
 </document>
 </documents>
 """
@@ -225,20 +225,20 @@ def test_xml_format_multiple_paths(tmpdir):
 
 <documents>
 <document index="1">
-  <source>
-    test_dir/file1.txt
-  </source>
-  <document_content>
+<source>
+test_dir/file1.txt
+</source>
+<document_content>
 Contents of file1
-  </document_content>
+</document_content>
 </document>
 <document index="2">
-  <source>
-    test_dir/file2.txt
-  </source>
-  <document_content>
+<source>
+test_dir/file2.txt
+</source>
+<document_content>
 Contents of file2
-  </document_content>
+</document_content>
 </document>
 </documents>
 """


### PR DESCRIPTION
I think specifying the path as an attribute in the XML tag makes a lot of sense that might work just as well while saving a decent amount of tokens, but it's also possible that exactly matching the structure Anthropic used for multi-file context during training could yield better results. I'm thinking about creating a related fork/PR that makes it easier to template how context items should be formatted to more easily allow trying multiple approaches to see what works best rather than relying on hard-coded formatting as is currently the case. 